### PR TITLE
test: Increase leader election process timeout to 3 seconds

### DIFF
--- a/tests/raft/aio/test_raft_aio.py
+++ b/tests/raft/aio/test_raft_aio.py
@@ -28,7 +28,7 @@ async def test_raft_aio_leader_election():
                 for server, port in zip(servers, ports)
             ],
             *raft_tasks,
-            asyncio.create_task(asyncio.sleep(1.0)),
+            asyncio.create_task(asyncio.sleep(3.0)),
         },
         return_when=asyncio.FIRST_COMPLETED,
     )

--- a/tests/raft/test_raft.py
+++ b/tests/raft/test_raft.py
@@ -27,5 +27,5 @@ def test_raft_leader_election():
     for server_thread, raft_thread in zip(server_threads, raft_threads):
         server_thread.start()
         raft_thread.start()
-    time.sleep(1.0)
+    time.sleep(3.0)
     assert any(map(lambda r: r.has_leadership(), raft_nodes))


### PR DESCRIPTION
In this PR, leader election process timeout has increased to 3s (previously 1s).
This is due to the assertion errors randomly caused during unit test process.