### PR TITLE
feat: Use a new distinct type for `RaftId`

### DIFF
--- a/aioraft/server.py
+++ b/aioraft/server.py
@@ -5,6 +5,7 @@ import grpc
 
 from aioraft.protocol import AbstractRaftProtocol
 from aioraft.protos import raft_pb2, raft_pb2_grpc
+from aioraft.types import RaftId
 
 
 class AbstractRaftServer(abc.ABC):
@@ -61,7 +62,7 @@ class GrpcRaftServer(AbstractRaftServer, raft_pb2_grpc.RaftServiceServicer):
             return raft_pb2.AppendEntriesResponse(term=request.term, success=False)
         term, success = await protocol.on_append_entries(
             term=request.term,
-            leader_id=request.leader_id,
+            leader_id=RaftId(request.leader_id),
             prev_log_index=request.prev_log_index,
             prev_log_term=request.prev_log_term,
             entries=request.entries,
@@ -78,7 +79,7 @@ class GrpcRaftServer(AbstractRaftServer, raft_pb2_grpc.RaftServiceServicer):
             return raft_pb2.RequestVoteResponse(term=request.term, vote_granted=False)
         term, vote_granted = await protocol.on_request_vote(
             term=request.term,
-            candidate_id=request.candidate_id,
+            candidate_id=RaftId(request.candidate_id),
             last_log_index=request.last_log_index,
             last_log_term=request.last_log_term,
         )

--- a/aioraft/types.py
+++ b/aioraft/types.py
@@ -1,7 +1,7 @@
 import enum
-from typing import Type, TypeVar
+from typing import NewType, Type, TypeVar
 
-RaftId = str
+RaftId = NewType("RaftId", str)
 
 
 class RaftState(enum.Enum):


### PR DESCRIPTION
This PR declares a new type `RaftId` using `typing.NewType` for higher accuracy of type checking.
When just aliasing a type, such as `RaftId = str`, a type checker could miss unintended type misses. It allows any `str` type value to be assigned to a slot for the `RaftId` type.
```python
RaftId = str

def f(x: RaftId):
  pass

f(x="any-string")  # mypy will pass here
```

However, with `typing.NewType` it supports mypy to catch a type miss more precisely.
```python
RaftId = typing.NewType("RaftId", str)

def f(x: RaftId):
  pass

f(x=RaftId("any-string"))  # mypy will pass here
f(x="any-string")  # mypy will raise an error
```

Reference
- https://docs.python.org/3/library/typing.html#newtype
