### PR TITLE
deps: Upgrade `grpcio` and `grpcio-tools` to 1.48.2

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -44,7 +44,7 @@ jobs:
         pip install -r requirements-dev.txt
     - name: Run mypy
       run: |
-        mypy ./aioraft
+        mypy ./aioraft --pretty
 
   test:
     runs-on: ubuntu-latest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 black
 flake8
-grpcio-tools~=1.47.0
+grpcio-tools==1.48.2
 isort
 mypy
 pytest~=7.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-grpcio~=1.47.0
+grpcio==1.48.2
 tomli~=2.0.1


### PR DESCRIPTION
This PR updates dependencies on `grpcio` and `grpcio-tools` as [lablup/backend.ai](https://github.com/lablup/backend.ai) updated in [this commit](https://github.com/lablup/backend.ai/commit/08295e25c0196b1f56ea8c1a207fc4e0454fef9c).