### PR TITLE
ci: Add environment to deploy job for PyPI trusted publishing

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -33,6 +33,9 @@ jobs:
     needs: [lint, typecheck, test]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://pypi.org/project/aioraft-ng/
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
## Summary

- The `deploy-to-pypi` job in the GitHub Actions workflow was missing the `environment` field, which caused PyPI trusted publishing to fail because the OIDC token's environment claim was absent.
- Added `environment: release` (with url `https://pypi.org/project/aioraft-ng/`) to the job so the OIDC token includes the required environment claim that matches the PyPI trusted publisher configuration.

Closes #42

## Test plan

- [ ] Verify the workflow YAML is valid
- [ ] Push a tag and confirm the deploy job successfully publishes to PyPI via trusted publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)